### PR TITLE
Don't codemod v1 route convention

### DIFF
--- a/packages/remix-to-react-router/src/config.ts
+++ b/packages/remix-to-react-router/src/config.ts
@@ -78,7 +78,7 @@ export const PACKAGE_CHANGES: Record<string, PackageChange> = {
     },
     packageSource: '@react-router/architect',
   },
-  '^@remix-run/(?!eslint-config)(.*)$': {
+  '^@remix-run/(?!(eslint-config|v1-route-convention))(.*)$': {
     source: '@react-router/$1',
   },
   '^react-router-dom$': {


### PR DESCRIPTION
v1 route convention package is still at https://www.npmjs.com/package/@remix-run/v1-route-convention